### PR TITLE
chore: update databricks-opencode to v0.5.0

### DIFF
--- a/Formula/databricks-opencode.rb
+++ b/Formula/databricks-opencode.rb
@@ -1,26 +1,26 @@
 class DatabricksOpencode < Formula
   desc "Transparent Databricks AI Gateway proxy for OpenCode CLI"
   homepage "https://github.com/IceRhymers/databricks-opencode"
-  version "0.4.1"
+  version "0.5.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.4.1/databricks-opencode-darwin-arm64"
-      sha256 "9b3924bf175f68437fae0db843bd865e350adff7a592a4e427b767611ba8c179"
+      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.5.0/databricks-opencode-darwin-arm64"
+      sha256 "a81968741955410eac21f1076fe5c5d748ae910c5d74c1d5420c3d3a77d9e311"
     else
-      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.4.1/databricks-opencode-darwin-amd64"
-      sha256 "cc3f46a5a783c1ee38a3a2a8ed7fd3aba54473d277e108e9581cf22501286ee2"
+      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.5.0/databricks-opencode-darwin-amd64"
+      sha256 "2e3b00ad61874620d631a81bf8c45de20f96933547e049555461636d8577e352"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.4.1/databricks-opencode-linux-arm64"
-      sha256 "256ead226c8c37dc1fbc8c42282edd11c4428b399c9264ca037e166bac73a56d"
+      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.5.0/databricks-opencode-linux-arm64"
+      sha256 "ff406644790ef1acc24d29f13a1fb0112e4addc48906e8b2c922c587453f4573"
     else
-      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.4.1/databricks-opencode-linux-amd64"
-      sha256 "fb012fbb0143bfa880c0f45ce7972e8556ff38fa89f51d555a0af3f540cb0234"
+      url "https://github.com/IceRhymers/databricks-opencode/releases/download/v0.5.0/databricks-opencode-linux-amd64"
+      sha256 "2ebe17a4844c614bfeb52944ae393e3b989b1c2cf28f1a6e607270ff87c85e8e"
     end
   end
 


### PR DESCRIPTION
Automated formula update for databricks-opencode v0.5.0.