### PR TITLE
fix: source release assets from the databricks-agents monorepo

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -24,9 +24,10 @@ jobs:
           VERSION: ${{ github.event.client_payload.version }}
         run: |
           mkdir -p /tmp/assets
+          # All tools release lockstep from the single monorepo; asset names stay per-tool.
           for PLATFORM in darwin-arm64 darwin-amd64 linux-amd64 linux-arm64; do
             gh release download "$TAG" \
-              --repo "IceRhymers/$TOOL" \
+              --repo "IceRhymers/databricks-agents" \
               --pattern "${TOOL}-${PLATFORM}" \
               --dir /tmp/assets
           done
@@ -68,9 +69,16 @@ jobs:
               content = f.read()
 
           for platform, sha in shas.items():
-              pattern = rf'(url "https://github\.com/IceRhymers/{re.escape(tool)}/releases/download/v[^/]+/{re.escape(tool)}-{re.escape(platform)}"\n\s+)sha256 "[^"]*"'
+              pattern = rf'(url "https://github\.com/IceRhymers/databricks-agents/releases/download/v[^/]+/{re.escape(tool)}-{re.escape(platform)}"\n\s+)sha256 "[^"]*"'
               replacement = rf'\1sha256 "{sha}"'
-              content = re.sub(pattern, replacement, content)
+              content, n = re.subn(pattern, replacement, content)
+              # A silent no-match would ship a bumped version with a stale sha256.
+              if n != 1:
+                  sys.exit(
+                      f"{formula_path}: expected 1 monorepo url/sha256 block for "
+                      f"{tool}-{platform}, matched {n}. Formula may still point at "
+                      f"an archived per-tool repo."
+                  )
 
           with open(formula_path, 'w') as f:
               f.write(content)

--- a/Formula/databricks-claude.rb
+++ b/Formula/databricks-claude.rb
@@ -1,25 +1,25 @@
 class DatabricksClaude < Formula
   desc "Transparent Databricks AI Gateway proxy for Claude Code"
-  homepage "https://github.com/IceRhymers/databricks-claude"
+  homepage "https://github.com/IceRhymers/databricks-agents"
   version "1.2.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/IceRhymers/databricks-claude/releases/download/v1.2.0/databricks-claude-darwin-arm64"
+      url "https://github.com/IceRhymers/databricks-agents/releases/download/v1.2.0/databricks-claude-darwin-arm64"
       sha256 "732a4c47d0dc0ae34b2e13b7221e273c4c8339b311317ccb7877673a6dc267c5"
     else
-      url "https://github.com/IceRhymers/databricks-claude/releases/download/v1.2.0/databricks-claude-darwin-amd64"
+      url "https://github.com/IceRhymers/databricks-agents/releases/download/v1.2.0/databricks-claude-darwin-amd64"
       sha256 "c519c2a69bc7882a9bdf1c02f2db4a118cd23f38f5ec39acce0e14ac4424a8dd"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/IceRhymers/databricks-claude/releases/download/v1.2.0/databricks-claude-linux-arm64"
+      url "https://github.com/IceRhymers/databricks-agents/releases/download/v1.2.0/databricks-claude-linux-arm64"
       sha256 "049b554b9332790141957500bf9aec989f7fea4b507e2c6e502dbefc28e2cfbb"
     else
-      url "https://github.com/IceRhymers/databricks-claude/releases/download/v1.2.0/databricks-claude-linux-amd64"
+      url "https://github.com/IceRhymers/databricks-agents/releases/download/v1.2.0/databricks-claude-linux-amd64"
       sha256 "c4811e0e361528b0b95293eb0c75babd6b9864d626f39090ad37a95026677904"
     end
   end


### PR DESCRIPTION
Closes #53. Also does the `databricks-claude.rb` repoint that was filed under #51 (now closed won't-fix for codex/opencode).

## What changed

**`.github/workflows/update-formula.yml`**
- Asset download now uses the fixed slug `IceRhymers/databricks-agents` instead of `IceRhymers/$TOOL`. Asset filenames are unchanged, so only the source repo moves.
- The Python sha256-rewrite regex is pinned to the monorepo slug.
- `re.sub` → `re.subn` with a hard exit unless exactly 1 block matches.

That last one is beyond what #53 asked for, and it matters: with the regex pinned to the monorepo, a formula still carrying an archived per-tool URL matches **zero** blocks. `re.sub` treats that as a no-op, so the workflow would have opened a PR with a bumped `version` and a **stale `sha256`** — surfacing much later as a confusing checksum mismatch at `brew install`. It now fails loudly at the source.

**`Formula/databricks-claude.rb`** — `homepage` + all four `url`s repointed at the monorepo. The existing `sha256`s already match the monorepo release digests byte-for-byte (same artifacts), so this is a pure URL swap. Not optional: the guard above would otherwise break claude's working auto-bump.

## Verification

Tapped this working copy locally:

| Formula | `brew fetch` (downloads + verifies sha256) | `brew audit --strict --online` |
|---|---|---|
| databricks-claude (repointed) | exit 0 | exit 0, 0 offenses |
| databricks-codex (unchanged) | exit 0 | exit 0, 0 offenses |
| databricks-opencode (unchanged) | exit 0 | exit 0, 0 offenses |

All four monorepo claude URLs return 200. Simulated the workflow's rewrite step against both formula states: claude rewrites all four SHAs cleanly; codex exits non-zero and leaves the file **untouched** rather than writing a stale checksum.

`brew install` could not be exercised locally — it fails with `Errno::EINVAL: apply2files` on **unmodified** formulae too, so it's a linuxbrew-on-Arch environment fault, not a formula defect. The `install`/`test` blocks are therefore covered by tap CI, not by me.

## On the frozen formulae

`databricks-codex.rb` and `databricks-opencode.rb` keep their archived-repo URLs and stay frozen (#51, won't-fix — no new artifacts, no users). They install fine today and are unaffected by this PR.

They will now permanently fail `update-formula.yml` if a dispatch ever arrives for them, since it requires monorepo URLs. That's intentional and unreachable: IceRhymers/databricks-agents#235 excludes them from the release dispatch fan-out.

## Merge order

Merge this before IceRhymers/databricks-agents#235, so the tap can handle a `databricks-agents` dispatch correctly. #52 (`databricks-agents.rb`) still needs a release that publishes `databricks-agents-*` assets — release-please IceRhymers/databricks-agents#234 will be the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)